### PR TITLE
Adjust extension menu (with settings) width

### DIFF
--- a/EXTRA MODS/Compact extensions menu/Style 1/cleaner_extensions_menu.css
+++ b/EXTRA MODS/Compact extensions menu/Style 1/cleaner_extensions_menu.css
@@ -36,7 +36,7 @@
 #unified-extensions-view .unified-extensions-item-name, 
 #unified-extensions-view .unified-extensions-item-message {
     padding-inline-start: 0.5em !important;
-    width: 21em !important;
+    width: 22em !important;
 }
 
 #unified-extensions-view .unified-extensions-item-action-button.subviewbutton {


### PR DESCRIPTION
Adjusted width to fit in text for extensions that  "can always read and change data"


Before change
---

 Default                | Web page
:-----------------------:|:-----------------------:
![before1](https://user-images.githubusercontent.com/78993606/235542424-f8d92f0b-659a-49f0-bc7b-dcbbaa8b7cbe.png)  |  ![before2](https://user-images.githubusercontent.com/78993606/235542432-a34d5db4-b08f-41fb-a6b4-23ed5bc4d3b7.png)


After change
---

 Default                | Web page
:-----------------------:|:-----------------------:
![change1](https://user-images.githubusercontent.com/78993606/235542436-db736802-2cd4-4e1d-a1e5-135e10a41ba9.png) | ![change2](https://user-images.githubusercontent.com/78993606/235542438-a3ba5099-8901-4d7b-abac-6ceab77ddbe2.png)
