### PR TITLE
Add light version of the Spill theme

### DIFF
--- a/ASSETS/other/spill-light.svg
+++ b/ASSETS/other/spill-light.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.dev/svgjs" viewBox="0 0 325 100">
+<defs><linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="ssspill-grad">
+<stop stop-color="hsl(200, 5%, 96%)" stop-opacity="1" offset="45%">
+</stop>
+<stop stop-color="hsl(290, 80%, 95%)" stop-opacity="1" offset="100%">
+</stop></linearGradient></defs>
+<rect width="100%" height="100%" fill="hsl(200, 5%, 90%)">
+</rect><g fill="url(#ssspill-grad)">
+    <rect width="100%" height="40" fill="hsl(200, 5%, 96%)"></rect>
+
+    <rect x="0" width="9.0909%" height="89.54254227345255" rx="15"></rect>
+      <rect x="18.1818181818%" width="9.0909%" height="63.65842205294875" rx="15"></rect>
+      <rect x="36.3636363636%" width="9.0909%" height="95.32661564144082" rx="15"></rect>
+      <rect x="54.545454545400005%" width="9.0909%" height="80.3369988625169" rx="15"></rect>
+      <rect x="72.7272727272%" width="9.0909%" height="83.02262368011036" rx="15"></rect>
+      <rect x="90.909090909%" width="9.0909%" height="91.29950540835866" rx="15"></rect>
+  </g><g fill="hsl(200, 5%, 90%)">
+    <rect x="9.0909%" y="8.458339590301716" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="27.272727272700003%" y="7.993587432454023" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="45.4545454545%" y="19.34017851601425" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="63.636363636300004%" y="6.150845968832461" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="81.8181818181%" y="16.968448561702075" width="9.0909%" height="60" rx="15"></rect>
+  </g></svg>

--- a/ASSETS/other/spill-main-light.svg
+++ b/ASSETS/other/spill-main-light.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.dev/svgjs" viewBox="0 0 325 100">
+<defs><linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="ssspill-grad">
+<stop stop-color="hsl(200, 5%, 96%)" stop-opacity="1" offset="45%">
+</stop>
+<stop stop-color="hsl(200, 0%, 100%)" stop-opacity="1" offset="100%">
+</stop></linearGradient></defs>
+<rect width="100%" height="100%" fill="hsl(200, 5%, 90%)">
+</rect><g fill="url(#ssspill-grad)">
+    <rect width="100%" height="40" fill="hsl(200, 5%, 96%)"></rect>
+
+    <rect x="0" width="9.0909%" height="89.54254227345255" rx="15"></rect>
+      <rect x="18.1818181818%" width="9.0909%" height="63.65842205294875" rx="15"></rect>
+      <rect x="36.3636363636%" width="9.0909%" height="95.32661564144082" rx="15"></rect>
+      <rect x="54.545454545400005%" width="9.0909%" height="80.3369988625169" rx="15"></rect>
+      <rect x="72.7272727272%" width="9.0909%" height="83.02262368011036" rx="15"></rect>
+      <rect x="90.909090909%" width="9.0909%" height="91.29950540835866" rx="15"></rect>
+  </g><g fill="hsl(200, 5%, 90%)">
+    <rect x="9.0909%" y="8.458339590301716" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="27.272727272700003%" y="7.993587432454023" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="45.4545454545%" y="19.34017851601425" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="63.636363636300004%" y="6.150845968832461" width="9.0909%" height="60" rx="15"></rect>
+      <rect x="81.8181818181%" y="16.968448561702075" width="9.0909%" height="60" rx="15"></rect>
+  </g></svg>

--- a/EXTRA THEMES/Spill/spill-style-part1-file.css
+++ b/EXTRA THEMES/Spill/spill-style-part1-file.css
@@ -6,11 +6,6 @@
         --firefoxcss-bookmarks-bg-color: hsl(240, 2%, 20%) !important;
     }
 }
-@media (prefers-color-scheme: light) {
-    :root {
-        --firefoxcss-bookmarks-bg-color: hsl(200, 0%, 95%) !important;
-    }
-}
 
 /* Main BAR */
 #main-window #navigator-toolbox {

--- a/EXTRA THEMES/Spill/spill-style-part2-file.css
+++ b/EXTRA THEMES/Spill/spill-style-part2-file.css
@@ -1,17 +1,28 @@
 /* Spill style. Modifications for userContent file */
 
-:root {
-  --firefoxcss-item-bg-color: hsla(240, 2%, 45%, 0.4) !important;
-  --firefoxcss-item-hover-bg-color: hsl(240, 2%, 55%, 0.4) !important;
-  --firefoxcss-settings-wheel-color: hsla(240, 20%, 80%, 0.6) !important;
-  --firefoxcss-settings-wheel-color-hover: hsla(240, 20%, 80%, 0.9) !important;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --firefoxcss-item-bg-color: hsla(240, 2%, 45%, 0.4) !important;
+    --firefoxcss-item-hover-bg-color: hsl(240, 2%, 55%, 0.4) !important;
+    --firefoxcss-settings-wheel-color: hsla(240, 20%, 80%, 0.6) !important;
+    --firefoxcss-settings-wheel-color-hover: hsla(240, 20%, 80%, 0.9) !important;
+  }
 }
 
 @-moz-document url("about:privatebrowsing") {
-  html:not(#ublock0-epicker),
-  html:not(#ublock0-epicker) body,
-  #newtab-customize-overlay {
-    background-image: url("ASSETS/other/spill.svg") !important;
+  @media (prefers-color-scheme: dark) {
+    html:not(#ublock0-epicker),
+    html:not(#ublock0-epicker) body,
+    #newtab-customize-overlay {
+      background-image: url("ASSETS/other/spill.svg") !important;
+    }
+  }
+  @media (prefers-color-scheme: light) {
+    html:not(#ublock0-epicker),
+    html:not(#ublock0-epicker) body,
+    #newtab-customize-overlay {
+      background-image: url("ASSETS/other/spill-light.svg") !important;
+    }
   }
 
   #search-handoff-button {
@@ -42,10 +53,19 @@
 
 @-moz-document url("about:home"),
 url("about:newtab") {
-  html:not(#ublock0-epicker),
-  html:not(#ublock0-epicker) body,
-  #newtab-customize-overlay {
-    background-image: url("ASSETS/other/spill-main.svg") !important;
+  @media (prefers-color-scheme: dark) {
+    html:not(#ublock0-epicker),
+    html:not(#ublock0-epicker) body,
+    #newtab-customize-overlay {
+      background-image: url("ASSETS/other/spill-main.svg") !important;
+    }
+  }
+  @media (prefers-color-scheme: light) {
+    html:not(#ublock0-epicker),
+    html:not(#ublock0-epicker) body,
+    #newtab-customize-overlay {
+      background-image: url("ASSETS/other/spill-main-light.svg") !important;
+    }
   }
 
   .body-wrapper .tile {


### PR DESCRIPTION
Hi @datguypiko.

I really like the Spill theme and have applied it to my Firefox.
However, it lacks light version, and sometimes I switch to light mode in a place with sufficient light.
Therefore, I made a light version background image for the theme to fit the use case.
I also took care of the background color of the bookmark bar, ensuring its color matches the image's top part.
Please take a look and tell me what else can I do.
Thanks!

P.S. I haven't modified the colors of min-max-buttons because I haven't figured out where can I update them.

Normal window:
![Screenshot From 2024-10-06 21-12-06](https://github.com/user-attachments/assets/6bc4dd68-ec8d-40a9-be31-c8f54494e1fa)

Private window (bookmark bar is hidden):
![Screenshot From 2024-10-06 21-10-44](https://github.com/user-attachments/assets/694c5496-b980-4b27-9903-65b9b9b79887)

By the way, to make private window's UI follows the system's dark/light preference, the option `browser.theme.dark-private-windows` should be set to `false`.
![image](https://github.com/user-attachments/assets/3323fd24-d70e-4732-b8d5-1e3b3b10ccee)