### PR TITLE
Add mod to push Bookmark bar instead of popping out

### DIFF
--- a/EXTRA MODS/Bookmarks Bar Mods/Popout bookmarks bar/push_bookmarks_bar_on_hover.css
+++ b/EXTRA MODS/Bookmarks Bar Mods/Popout bookmarks bar/push_bookmarks_bar_on_hover.css
@@ -1,0 +1,36 @@
+:root {
+  --uc-bm-height: 24px;
+  --uc-bm-padding: 6px;
+}
+
+#PersonalToolbar {
+  padding: 1px 6px !important;
+  height: 0px !important;
+  opacity: 0 !important;
+  transition-property: height, opacity !important;
+  transition-duration: 300ms, 300ms !important;
+  transition-delay: 200ms, 200ms !important;
+  transition-timing-function: ease-in-out, ease-in-out !important;
+}
+
+#navigator-toolbox:hover:not(:has(#urlbar[breakout][breakout-extend]:hover)) > #PersonalToolbar,
+#PersonalToolbar:has(.bookmark-item[open]),
+#navigator-toolbox > #PersonalToolbar:has(.toolbar-menupopup[dragstart]) {
+  height: calc(var(--uc-bm-height) + 2*var(--uc-bm-padding)) !important;
+  opacity: 1 !important;
+}
+
+:root[uidensity="touch"] #PersonalToolbar {
+  --uc-bm-padding: 6px;
+}
+
+/* Firefox v133 fix */
+#navigator-toolbox{
+  --browser-area-z-index-toolbox: 4;
+}
+
+/* Fix navigator-toolbox absolute elements when in fullscreen. Like in fullscreen video. */
+:root[inDOMFullscreen] #navigator-toolbox {
+	--browser-area-z-index-toolbox: initial;
+}
+

--- a/userChrome.css
+++ b/userChrome.css
@@ -24,7 +24,11 @@
 @import url("min-max-close_buttons.css");
 @import url("acrylic_micaforeveryone.css");
 @import url("privacy_blur_tabs_content.css");
+
+/* Use only one of the two methods below to change how the bookmark bar hide */
 @import url("popout_bookmarks_bar_on_hover.css");
+/* @import url("push_bookmarks_bar_on_hover.css"); */
+
 @import url("remove_folder_icons_from_bookmarks.css");
 @import url("icons_in_main_menu.css");
 @import url("ublock-icon-change.css");


### PR DESCRIPTION
Hi, I want to suggest an extra mod, an alternate way to hide the bookmark. Currently, using the `popout_bookmarks_bar_on_hover.css`, the top parts of the browser as well as the side bar would be covered when the bookmark bar is visible, adding a delay before users can interact with those areas. I'm suggesting an alternative mod that would instead push those parts down when visible and raise those parts up when hidden, similar to the behavior when toggling the `Ctrl+Shift+b` hotkey.

I've also added some changes/fix to some current behaviors that maybe can be added to the current version as well:
- When the URL bar is entered/extended, hovering the area in the URL bar would make the bookmark bar pop out in the background. The alternate version let it hide or not show up at all.
- When there is a bookmark folder open, hovering outside the dropdown area of the folder would make the bookmark hide while still leave the dropdown area hanging. The alternate version keep the bookmark bar open.

Current behavior:
![Current_Bookmark_Bar_Hide](https://github.com/user-attachments/assets/4e33469c-cf61-4e80-99b5-c258a7e455c7)

Alternative behavior:
![Alternative_Bookmark_Bar_Hide](https://github.com/user-attachments/assets/12240d17-aba4-44f5-8445-661fe5262676)

Please review and let me know what you think. Thank you.