### PR TITLE
Fix push_bookmarks_bar_on_hover

### DIFF
--- a/EXTRA MODS/Bookmarks Bar Mods/Popout bookmarks bar/push_bookmarks_bar_on_hover.css
+++ b/EXTRA MODS/Bookmarks Bar Mods/Popout bookmarks bar/push_bookmarks_bar_on_hover.css
@@ -4,20 +4,26 @@
 }
 
 #PersonalToolbar {
-  padding: 1px 6px !important;
+  padding: 0px !important;
   height: 0px !important;
   opacity: 0 !important;
-  transition-property: height, opacity !important;
-  transition-duration: 300ms, 300ms !important;
-  transition-delay: 200ms, 200ms !important;
-  transition-timing-function: ease-in-out, ease-in-out !important;
+  transition-property: height, opacity, padding !important;
+  transition-duration: 300ms, 300ms, 0ms !important;
+  transition-delay: 200ms, 200ms, 500ms !important;
+  transition-timing-function: ease-in-out, ease-in-out, ease-in-out !important;
 }
 
 #navigator-toolbox:hover:not(:has(#urlbar[breakout][breakout-extend]:hover)) > #PersonalToolbar,
 #PersonalToolbar:has(.bookmark-item[open]),
-#navigator-toolbox > #PersonalToolbar:has(.toolbar-menupopup[dragstart]) {
+#navigator-toolbox > #PersonalToolbar:has(.toolbar-menupopup[dragstart]),
+#PersonalToolbar[customizing] {
+  padding: 1px 6px !important;
   height: calc(var(--uc-bm-height) + 2*var(--uc-bm-padding)) !important;
   opacity: 1 !important;
+  transition-property: height, opacity, padding !important;
+  transition-duration: 300ms, 300ms, 0ms !important;
+  transition-delay: 200ms, 200ms, 200ms !important;
+  transition-timing-function: ease-in-out, ease-in-out, linear !important;
 }
 
 :root[uidensity="touch"] #PersonalToolbar {


### PR DESCRIPTION
Hi, I want to submit a fix for 2 bugs:
1. Bookmark bar is hidden unless hovered when customizing toolbar
- Current behavior:
![Current_push_bookmark_bar_customizing](https://github.com/user-attachments/assets/ea99cd74-71b5-45bc-8921-931914c78ad5)

- Fixed behavior:
![Fixed_push_bookmark_bar_customizing](https://github.com/user-attachments/assets/742bc6c7-0982-435d-87a8-10db1542e26d)

2. Bookmark bar's padding is visible while the bookmark bar is hidden, creating a visible line under the tab bar.
- Current behavior:
![Current_push_bookmark_bar](https://github.com/user-attachments/assets/d6df0c01-749b-443a-9790-f044d7fed434)

- Fixed behavior:
![Fixed_push_bookmark_bar](https://github.com/user-attachments/assets/98f2984e-ecea-438d-b011-6902bb48ba42)

Please review these changes. Thank you.
