### PR TITLE
Fix Duplicated Min-Max-Close Button Group on Linux

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1813,20 +1813,6 @@ mask-composite: intersect;
     padding-inline-start: 2px !important;
   }
 
-  #nav-bar {
-    padding-right: var(--firefoxcss-control-buttons-margin) !important;
-  }
-
-  #navigator-toolbox:not([inFullscreen])
-    #TabsToolbar
-    .titlebar-buttonbox-container {
-    visibility: visible !important;
-    display: flex !important;
-    position: absolute !important;
-    top: 1px;
-    right: 0;
-  }
-
   #TabsToolbar .titlebar-buttonbox-container .titlebar-button {
     border-radius: var(--toolbarbutton-border-radius);
   }
@@ -1839,33 +1825,49 @@ mask-composite: intersect;
     padding-right: initial !important;
   }
 
-  .titlebar-buttonbox-container .titlebar-min {
-    order: 0 !important;
-  }
+  @media not (-moz-bool-pref: "sidebar.verticalTabs") {
+    #nav-bar {
+      padding-right: var(--firefoxcss-control-buttons-margin) !important;
+    }
 
-  .titlebar-buttonbox-container .titlebar-max,
-  .titlebar-restore {
-    order: 1 !important;
-  }
-
-  .titlebar-buttonbox-container .titlebar-close {
-    order: 2 !important;
-  }
-
-  @media only screen and (max-width: 670px) {
     #navigator-toolbox:not([inFullscreen])
       #TabsToolbar
       .titlebar-buttonbox-container {
       visibility: visible !important;
       display: flex !important;
-      position: relative !important;
-      order: 1 !important;
-      padding-top: 1px !important;
-      padding-bottom: 1px !important;
+      position: absolute !important;
+      top: 1px;
+      right: 0;
     }
 
-    #navigator-toolbox:not([inFullscreen]) #nav-bar {
-      padding-right: initial !important;
+    .titlebar-buttonbox-container .titlebar-min {
+      order: 0 !important;
+    }
+
+    .titlebar-buttonbox-container .titlebar-max,
+    .titlebar-restore {
+      order: 1 !important;
+    }
+
+    .titlebar-buttonbox-container .titlebar-close {
+      order: 2 !important;
+    }
+
+    @media only screen and (max-width: 670px) {
+      #navigator-toolbox:not([inFullscreen])
+        #TabsToolbar
+        .titlebar-buttonbox-container {
+        visibility: visible !important;
+        display: flex !important;
+        position: relative !important;
+        order: 1 !important;
+        padding-top: 1px !important;
+        padding-bottom: 1px !important;
+      }
+
+      #navigator-toolbox:not([inFullscreen]) #nav-bar {
+        padding-right: initial !important;
+      }
     }
   }
 }


### PR DESCRIPTION
I recently enabled native vertical tabs in Firefox and noticed that there is a duplicated min-max-close button group in the title bar, as shown in the screenshot below.

![Screenshot From 2025-03-30 19-50-32](https://github.com/user-attachments/assets/742c4ad8-a2cd-4d27-9796-4bf0ab0ae0bf)

I found that it was due to a media query regarding vertical tabs missed in the Linux section of CSS.
After adding the media query, the duplicated button group was gone.

![Screenshot From 2025-03-30 19-56-34](https://github.com/user-attachments/assets/f8083800-8dbe-443e-97da-70ae48e2c28d)

Please review this PR. Thank You.