### PR TITLE
Modify GitHub Icons in folders & allow paths after TLD

### DIFF
--- a/EXTRA MODS/Icon and Button Mods/White github icon/white_github_icon_in_bookmarks.css
+++ b/EXTRA MODS/Icon and Button Mods/White github icon/white_github_icon_in_bookmarks.css
@@ -1,5 +1,5 @@
 /* Change github icon in bookmarks bar to white color one */
-.bookmark-item[image="page-icon:https://github.com/"] > .toolbarbutton-icon {
+.bookmark-item[image^="page-icon:https://github.com/"] > :is(.toolbarbutton-icon, .menu-icon) {
 	width: 0px !important;
 	height: 0px !important;
 	padding: 0 0 16px 16px !important;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b36207e5-9a40-42ad-bdf6-e236b60bed3a)
Without the added class selector, both of these GitHub icons would still be black.
Without the ^= comparison, the bottom one would still be black.