### PR TITLE
Fix purple flash when switching private tabs and hide the info block globally

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -468,12 +468,15 @@ Order of Toolbars
 
 /* Fix purple background color when switching tabs in private 
 window for this specific moz preference. */
-:root {
-  &[privatebrowsingmode="temporary"] {
-    @media -moz-pref("browser.privatebrowsing.felt-privacy-v1") {
-      --tabpanel-background-color: var(--firefoxcss-main-bg-color) !important;
-    }
-  }
+/* Prevent the purple flash on opening/switching private tabs */
+:root[privatebrowsingmode="temporary"] {
+  --tabpanel-background-color: var(--firefoxcss-main-bg-color) !important;
+}
+
+#tabbrowser-tabpanels,
+browser[type="content"],
+.browserStack {
+  background-color: var(--firefoxcss-main-bg-color) !important;
 }
 
 /* Website Loading Background color fix */

--- a/userContent.css
+++ b/userContent.css
@@ -186,16 +186,14 @@
 
   /* Fix purple background color when switching tabs in private 
 window for this specific moz preference. */
-  @media -moz-pref("browser.privatebrowsing.felt-privacy-v1") {
-    html.private {
-      --background-color-canvas: var(--firefoxcss-main-bg-color) !important;
-      background: var(--firefoxcss-main-bg-color) !important;
-    }
+   html.private {
+	  --background-color-canvas: var(--firefoxcss-main-bg-color) !important;
+	  background: var(--firefoxcss-main-bg-color) !important;
+   }
 
-    .info-border {
-      display: none !important;
-    }
-  }
+   .info-border {
+	  display: none !important;
+   }
 
   /* html.private {
 		background-color: #1e1e1e80 !important;


### PR DESCRIPTION
The fixes for the private browsing page were previously wrapped in the `browser.privatebrowsing.felt-privacy-v1` media query, meaning they only worked if that experimental setting was turned on in `about:config`. 

I removed this media query from both `userChrome.css` and `userContent.css`. Now, the purple flash is resolved when switching private tabs, and the `.info-border` block is successfully hidden for all users.