### PR TITLE
fix: set urlbar selected text color for light mode

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -232,6 +232,7 @@
     --urlbarview-background-color-hover: var(--urlbarView-hover-background) !important;
     --urlbarView-hover-background: color-mix(in srgb, currentColor 6%, transparent) !important;
     --urlbarView-highlight-background: color-mix(in srgb, currentColor 12%, transparent) !important;
+    --urlbarview-text-color-selected: black !important;
 
     /* ============== Firefox Global colors change ==================== */
     &:not([lwtheme]) {


### PR DESCRIPTION
Before: 
<img width="800" height="180" alt="screenshot-2026-07-16-23-18-00" src="https://github.com/user-attachments/assets/345074d4-b091-4d23-a33a-d558400a37d2" />

After:
<img width="800" height="180" alt="screenshot-2026-07-16-23-17-38" src="https://github.com/user-attachments/assets/85734163-b800-41a7-91fc-5eb6f237a473" />
